### PR TITLE
feat: 新增 SHEIN 开放平台 scraper 及文档同步

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,9 @@ verify: ## 健康检查（最多重试 30s）
 	echo "✗ 健康检查失败"; exit 1
 
 # ─── 文档同步（需先 npm run dev 启动本地服务）──────
-.PHONY: sync sync-feishu sync-wecom sync-dingtalk sync-xiaohongshu sync-taobao sync-douyin sync-wechat-miniprogram sync-wechat-shop sync-pinduoduo sync-youzan sync-wechat-pay sync-alipay sync-jd
+.PHONY: sync sync-feishu sync-wecom sync-dingtalk sync-xiaohongshu sync-taobao sync-douyin sync-wechat-miniprogram sync-wechat-shop sync-pinduoduo sync-youzan sync-wechat-pay sync-alipay sync-jd sync-shein
 
-sync: sync-feishu sync-wecom sync-dingtalk sync-xiaohongshu sync-taobao sync-douyin sync-wechat-miniprogram sync-wechat-shop sync-pinduoduo sync-youzan sync-wechat-pay sync-alipay sync-jd ## 同步全部源到 data/specfusion.db
+sync: sync-feishu sync-wecom sync-dingtalk sync-xiaohongshu sync-taobao sync-douyin sync-wechat-miniprogram sync-wechat-shop sync-pinduoduo sync-youzan sync-wechat-pay sync-alipay sync-jd sync-shein ## 同步全部源到 data/specfusion.db
 
 sync-feishu: ## 同步飞书文档
 	npm run sync -- --source feishu
@@ -92,6 +92,9 @@ sync-alipay: ## 同步支付宝开放平台文档
 
 sync-jd: ## 同步京东商家开放平台文档
 	npm run sync -- --source jd
+
+sync-shein: ## 同步SHEIN开放平台文档
+	npm run sync -- --source shein
 
 # ─── 数据库上传到 K8s ────────────────────────────────
 .PHONY: upload-db

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SpecFusion
 
-**在 Claude Code 里直接搜企业微信、飞书、钉钉、淘宝开放平台、小红书、抖音电商开放平台、微信小程序、微信小店、拼多多开放平台、有赞开放平台、微信支付、支付宝开放平台、京东商家开放平台的 API 文档。**
+**在 Claude Code 里直接搜企业微信、飞书、钉钉、淘宝开放平台、小红书、抖音电商开放平台、微信小程序、微信小店、拼多多开放平台、有赞开放平台、微信支付、支付宝开放平台、京东商家开放平台、SHEIN开放平台的 API 文档。**
 
 不用切浏览器，不用翻文档站——输入问题，拿到接口参数，继续写代码。
 
@@ -17,7 +17,7 @@
 
 - **不离开终端** — 写代码时直接问，Claude 帮你查文档、给出接口参数和示例
 - **中文搜索准确** — jieba 分词 + FTS5 全文索引，`发送应用消息`、`access_token`、`40001` 都能搜到
-- **26,350+ 篇文档** — 企业微信 ~2,680 篇 + 飞书 ~4,070 篇 + 钉钉 ~2,020 篇 + 淘宝 ~6,740 篇 + 小红书 ~100 篇 + 抖音电商 ~1,280 篇 + 微信小程序 ~280 篇 + 微信小店 ~480 篇 + 拼多多 ~280 篇 + 有赞 ~1,240 篇 + 微信支付 ~540 篇 + 支付宝 ~600 篇 + 京东 ~6,100 篇，接口参数、错误码、事件订阅全覆盖
+- **26,580+ 篇文档** — 企业微信 ~2,680 篇 + 飞书 ~4,070 篇 + 钉钉 ~2,020 篇 + 淘宝 ~6,740 篇 + 小红书 ~100 篇 + 抖音电商 ~1,280 篇 + 微信小程序 ~280 篇 + 微信小店 ~480 篇 + 拼多多 ~280 篇 + 有赞 ~1,240 篇 + 微信支付 ~540 篇 + 支付宝 ~600 篇 + 京东 ~6,100 篇 + SHEIN ~190 篇，接口参数、错误码、事件订阅全覆盖
 - **零配置** — 云端服务已部署好，安装 Skill 后即可使用，无需自建后端
 
 ## 安装
@@ -43,7 +43,7 @@ Invoke-WebRequest -Uri "https://raw.githubusercontent.com/wxkingstar/SpecFusion/
 
 ## 使用方式
 
-**方式一：直接提问**（提到企业微信、飞书、钉钉、淘宝、小红书、抖音电商、微信小程序、微信小店、拼多多、有赞、微信支付、支付宝、京东等关键词时自动触发）
+**方式一：直接提问**（提到企业微信、飞书、钉钉、淘宝、小红书、抖音电商、微信小程序、微信小店、拼多多、有赞、微信支付、支付宝、京东、SHEIN等关键词时自动触发）
 
 ```
 > 飞书如何创建审批实例？
@@ -58,6 +58,7 @@ Invoke-WebRequest -Uri "https://raw.githubusercontent.com/wxkingstar/SpecFusion/
 > wecom webhook 怎么发消息？
 > 微信支付JSAPI下单接口怎么调？
 > 支付宝当面付接口怎么用？
+> SHEIN商品发布接口怎么调？
 ```
 
 **方式二：使用 `/specfusion` 命令**
@@ -84,6 +85,7 @@ Invoke-WebRequest -Uri "https://raw.githubusercontent.com/wxkingstar/SpecFusion/
 | 微信支付 | ~540 | JSAPI/APP/H5/Native/小程序支付、退款、分账、合单支付、代金券、商家转账等 API |
 | 支付宝开放平台 | ~600 | 当面付、APP支付、手机网站支付、电脑网站支付、资金、会员、营销、安全等 API |
 | 京东商家开放平台 | ~6,100 | 商品、订单、物流、售后、促销、店铺、数据、发票、供应商等 API |
+| SHEIN开放平台 | ~190 | 密钥授权、商品、订单、退货退款、采购单、库存、财务、物流、Webhook 等 API |
 
 ## 仅在当前项目安装
 
@@ -158,6 +160,7 @@ npm run sync -- --source youzan      # 同步有赞开放平台文档
 npm run sync -- --source wechat-pay  # 同步微信支付文档
 npm run sync -- --source alipay      # 同步支付宝开放平台文档
 npm run sync -- --source jd          # 同步京东商家开放平台文档
+npm run sync -- --source shein       # 同步SHEIN开放平台文档
 ```
 
 同步完成后数据库文件位于 `data/specfusion.db`。
@@ -191,7 +194,7 @@ Base URL: `http://localhost:3456/api`（自部署）
 | 参数 | 必填 | 说明 |
 |------|------|------|
 | `q` | 是 | 搜索关键词（接口名、API 路径、错误码、功能概念） |
-| `source` | 否 | 文档来源：`wecom` / `feishu` / `dingtalk` / `taobao` / `xiaohongshu` / `douyin` / `wechat-miniprogram` / `wechat-shop` / `pinduoduo` / `youzan` / `wechat-pay` / `alipay` / `jd` |
+| `source` | 否 | 文档来源：`wecom` / `feishu` / `dingtalk` / `taobao` / `xiaohongshu` / `douyin` / `wechat-miniprogram` / `wechat-shop` / `pinduoduo` / `youzan` / `wechat-pay` / `alipay` / `jd` / `shein` |
 | `mode` | 否 | 开发模式（仅企业微信）：`internal` / `third_party` / `service_provider` |
 | `limit` | 否 | 返回数量，默认 5，最大 20 |
 

--- a/api/src/routes/categories.ts
+++ b/api/src/routes/categories.ts
@@ -15,6 +15,7 @@ const SOURCE_NAME_MAP: Record<string, string> = {
   'wechat-pay': '微信支付',
   alipay: '支付宝开放平台',
   jd: '京东商家开放平台',
+  shein: 'SHEIN开放平台',
 };
 
 function sourceName(sourceId: string): string {

--- a/api/src/routes/recent.ts
+++ b/api/src/routes/recent.ts
@@ -15,6 +15,7 @@ const SOURCE_NAME_MAP: Record<string, string> = {
   'wechat-pay': '微信支付',
   alipay: '支付宝开放平台',
   jd: '京东商家开放平台',
+  shein: 'SHEIN开放平台',
 };
 
 function sourceName(sourceId: string): string {

--- a/api/src/services/search-engine.ts
+++ b/api/src/services/search-engine.ts
@@ -20,6 +20,7 @@ const SOURCE_NAME_MAP: Record<string, string> = {
   'wechat-pay': '微信支付',
   alipay: '支付宝开放平台',
   jd: '京东商家开放平台',
+  shein: 'SHEIN开放平台',
 };
 
 function sourceName(sourceId: string): string {

--- a/scrapers/config/sources.yaml
+++ b/scrapers/config/sources.yaml
@@ -64,3 +64,10 @@ sources:
     schedule: "0 10 * * 0"
     options:
       concurrency: 1
+
+  - id: shein
+    name: SHEIN开放平台
+    adapter: shein
+    schedule: "0 11 * * 0"
+    options:
+      concurrency: 3

--- a/scrapers/src/sources/shein.ts
+++ b/scrapers/src/sources/shein.ts
@@ -1,0 +1,581 @@
+import axios, { type AxiosInstance } from 'axios';
+import { load, type CheerioAPI } from 'cheerio';
+import { decode } from 'html-entities';
+import { tokenize } from '../utils/tokenizer.js';
+import { collapseBlankLines, stripHtmlComments } from '../utils/html-to-md.js';
+import type { DocSource, DocEntry, DocContent } from '../types.js';
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const BASE_URL = 'https://open.sheincorp.com';
+const API_BASE = `${BASE_URL}/api`;
+const USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36';
+
+/** 请求间隔（ms） */
+const REQUEST_DELAY = 300;
+
+/** 错误码分页大小 */
+const ERROR_PAGE_SIZE = 100;
+
+// ─── API response interfaces ────────────────────────────────────────────────
+
+interface SheinResponse<T> {
+  code: string;
+  msg: string;
+  info: T;
+}
+
+interface SheinCategory {
+  id: number;
+  categoryName: string;
+  categoryDesc: string;
+  docType: { key: number; value: string; data: string };
+  apiDocVoList: SheinApiDocVo[];
+}
+
+interface SheinApiDocVo {
+  id: number;
+  openPath: string;
+  title: string;
+  docName: string;
+  userDocName: string;
+  method: string;
+  docType: { key: number; value: string; data: string };
+  isEvaluate: number;
+  categoryId: number;
+}
+
+interface SheinDetailResponse {
+  mode: number[];
+  modeNameList: string[];
+  apiPublishDocVo: {
+    id: number;
+    openPath: string;
+    title: string;
+    userDocName: string;
+    method: string;
+    changeContent: string;
+    docType: { key: number; value: string; data: string };
+    version: number;
+    updateTime: string;
+    categoryId: number;
+    qpsContent: string;
+  };
+  apiPublishDocDetailVo: {
+    id: number;
+    openPath: string;
+    title: string;
+    userDocName: string;
+    method: string;
+    description: string;
+    docType: { key: number; value: string; data: string };
+    updateTime: string;
+    queryStrings: string;
+    requestExample: string;
+    responseExample: string;
+    requestHeader: string;
+    requestBody: string;
+    responseHeader: string | null;
+    responseBody: string;
+    apiPublishDocExampleDetailVo: Array<{
+      sceneName: string;
+      requestExample: string;
+      responseExample: string;
+      sort: number;
+    }>;
+  };
+}
+
+interface SheinErrorItem {
+  id: number;
+  openPath: string;
+  errorCode: string;
+  errorMsg: string;
+  errorMsgCn: string;
+  solution: string;
+}
+
+interface SheinErrorListResponse {
+  data: SheinErrorItem[];
+  total: number;
+}
+
+/** JSON 参数树中的节点 */
+interface ParamNode {
+  props: {
+    type?: string;
+    name?: string;
+    description?: string;
+    required?: boolean;
+    label?: string;
+  };
+  children?: ParamNode[];
+}
+
+// ─── Utility helpers ────────────────────────────────────────────────────────
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function escapeCell(text: string): string {
+  if (!text) return '';
+  return text.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+/** 从 HTML 字符串中提取纯文本（用于参数描述） */
+function stripHtml(html: string): string {
+  if (!html) return '';
+  const $ = load(html);
+  return decode($.root().text()).trim();
+}
+
+// ─── HTML → Markdown conversion ─────────────────────────────────────────────
+
+function htmlToMarkdown(html: string): string {
+  if (!html || !html.trim()) return '';
+
+  const $: CheerioAPI = load(html);
+
+  // Convert code blocks
+  $('pre').each((_, el) => {
+    const $el = $(el);
+    const code = $el.find('code');
+    const lang = code.attr('class')?.replace(/^language-/, '') || '';
+    const text = decode(code.length ? code.text() : $el.text());
+    $el.replaceWith(`\n\`\`\`${lang}\n${text}\n\`\`\`\n`);
+  });
+
+  // Convert inline code
+  $('code').each((_, el) => {
+    const $el = $(el);
+    const text = $el.text().trim();
+    if (text) {
+      $el.replaceWith(`\`${text}\``);
+    }
+  });
+
+  // Convert headings
+  for (let i = 1; i <= 6; i++) {
+    $(`h${i}`).each((_, el) => {
+      const $el = $(el);
+      const text = $el.text().trim();
+      if (text) {
+        $el.replaceWith(`\n${'#'.repeat(i)} ${text}\n`);
+      }
+    });
+  }
+
+  // Convert links
+  $('a').each((_, el) => {
+    const $el = $(el);
+    const href = $el.attr('href') || '';
+    const text = $el.text().trim();
+    if (text && href && !href.startsWith('javascript:')) {
+      const fullHref = href.startsWith('http') ? href : `${BASE_URL}${href}`;
+      $el.replaceWith(`[${text}](${fullHref})`);
+    } else if (text) {
+      $el.replaceWith(text);
+    }
+  });
+
+  // Convert images
+  $('img').each((_, el) => {
+    const $el = $(el);
+    const src = $el.attr('src') || '';
+    const alt = $el.attr('alt') || '';
+    if (src) {
+      $el.replaceWith(`![${alt}](${src})`);
+    }
+  });
+
+  // Convert tables
+  $('table').each((_, table) => {
+    const $table = $(table);
+    const rows: string[][] = [];
+    let maxCols = 0;
+
+    $table.find('tr').each((_, tr) => {
+      const cells: string[] = [];
+      $(tr)
+        .find('th, td')
+        .each((_, cell) => {
+          cells.push($(cell).text().trim().replace(/\n/g, ' '));
+        });
+      if (cells.length > maxCols) maxCols = cells.length;
+      rows.push(cells);
+    });
+
+    if (rows.length === 0) return;
+
+    const lines: string[] = [];
+    const header = rows[0];
+    while (header.length < maxCols) header.push('');
+    lines.push(`| ${header.map(escapeCell).join(' | ')} |`);
+    lines.push(`| ${header.map(() => '---').join(' | ')} |`);
+
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i];
+      while (row.length < maxCols) row.push('');
+      lines.push(`| ${row.map(escapeCell).join(' | ')} |`);
+    }
+
+    $table.replaceWith(`\n${lines.join('\n')}\n`);
+  });
+
+  // Convert lists
+  $('ul, ol').each((_, list) => {
+    const $list = $(list);
+    const isOrdered = list.tagName === 'ol';
+    const items: string[] = [];
+    $list.children('li').each((idx, li) => {
+      const prefix = isOrdered ? `${idx + 1}. ` : '- ';
+      items.push(`${prefix}${$(li).text().trim()}`);
+    });
+    $list.replaceWith(`\n${items.join('\n')}\n`);
+  });
+
+  // Convert <br> to newline
+  $('br').replaceWith('\n');
+
+  // Convert <p> to paragraphs
+  $('p').each((_, el) => {
+    const $el = $(el);
+    const text = $el.text().trim();
+    if (text) {
+      $el.replaceWith(`\n${$el.html()}\n`);
+    }
+  });
+
+  // Convert bold/strong
+  $('strong, b').each((_, el) => {
+    const $el = $(el);
+    const text = $el.text().trim();
+    if (text) {
+      $el.replaceWith(`**${text}**`);
+    }
+  });
+
+  // Convert italic/em
+  $('em, i').each((_, el) => {
+    const $el = $(el);
+    const text = $el.text().trim();
+    if (text) {
+      $el.replaceWith(`*${text}*`);
+    }
+  });
+
+  let md = decode($.root().text());
+  md = stripHtmlComments(md);
+  md = md.replace(/<[^>]+>/g, '');
+  md = collapseBlankLines(md);
+  md = md.trim();
+
+  return md;
+}
+
+// ─── JSON param tree → Markdown table ───────────────────────────────────────
+
+function paramTreeToTable(jsonStr: string, depth = 0): string {
+  if (!jsonStr) return '';
+
+  let root: ParamNode;
+  try {
+    root = JSON.parse(jsonStr);
+  } catch {
+    return '';
+  }
+
+  const children = root.children;
+  if (!children || children.length === 0) return '';
+
+  const rows: string[] = [];
+  rows.push('| 参数名称 | 数据类型 | 是否必须 | 描述 |');
+  rows.push('| --- | --- | --- | --- |');
+
+  function walkNode(node: ParamNode, level: number): void {
+    const p = node.props;
+    if (!p.name) return;
+
+    const indent = level > 0 ? '&nbsp;'.repeat(level * 2) + '└ ' : '';
+    const name = `${indent}${p.name}`;
+    const type = p.type || '';
+    const required = p.required ? '是' : '否';
+    const desc = escapeCell(stripHtml(p.description || p.label || ''));
+
+    rows.push(`| ${escapeCell(name)} | ${type} | ${required} | ${desc} |`);
+
+    if (node.children) {
+      for (const child of node.children) {
+        walkNode(child, level + 1);
+      }
+    }
+  }
+
+  for (const child of children) {
+    walkNode(child, depth);
+  }
+
+  return rows.join('\n');
+}
+
+// ─── SheinSource class ─────────────────────────────────────────────────────
+
+export class SheinSource implements DocSource {
+  id = 'shein';
+  name = 'SHEIN开放平台';
+
+  private client: AxiosInstance;
+  private requestCount = 0;
+  /** category id → name */
+  private categoryMap = new Map<number, string>();
+
+  constructor() {
+    this.client = axios.create({
+      baseURL: API_BASE,
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'application/json, text/plain, */*',
+        'Accept-Language': 'zh-CN,zh;q=0.9',
+        Referer: `${BASE_URL}/documents/apidoc/detail/3001520`,
+      },
+      timeout: 30_000,
+    });
+  }
+
+  // ─── Rate limiting ─────────────────────────────────────────────────────
+
+  private async throttle(): Promise<void> {
+    this.requestCount++;
+    if (this.requestCount % 50 === 0) {
+      console.log(`[shein] 已发送 ${this.requestCount} 个请求`);
+    }
+    await delay(REQUEST_DELAY);
+  }
+
+  // ─── API calls ─────────────────────────────────────────────────────────
+
+  /** 获取某类文档的分类目录（categoryType=1 为 API 文档，2 为 Webhook 消息文档） */
+  private async fetchCategoryList(categoryType: number): Promise<SheinCategory[]> {
+    await this.throttle();
+    const resp = await this.client.get<SheinResponse<SheinCategory[]>>(
+      '/api/apiDoc/queryAllApiDocCategoryList',
+      { params: { categoryType } },
+    );
+    if (resp.data.code !== '0') {
+      throw new Error(`获取分类列表失败 (type=${categoryType}): ${resp.data.msg}`);
+    }
+    return resp.data.info;
+  }
+
+  /** 获取单篇文档详情 */
+  private async fetchDetail(docId: number): Promise<SheinDetailResponse> {
+    await this.throttle();
+    const resp = await this.client.get<SheinResponse<SheinDetailResponse>>(
+      '/api/apiDoc/queryApiPublishDocDetailInfoById',
+      { params: { id: docId, isLatest: true } },
+    );
+    if (resp.data.code !== '0') {
+      throw new Error(`获取文档 ${docId} 详情失败: ${resp.data.msg}`);
+    }
+    return resp.data.info;
+  }
+
+  /** 获取文档的错误码列表 */
+  private async fetchErrorList(openPath: string): Promise<SheinErrorItem[]> {
+    await this.throttle();
+    try {
+      const resp = await this.client.post<SheinResponse<SheinErrorListResponse>>(
+        '/api/apiDoc/error/list',
+        { openPath, page: 1, pageSize: ERROR_PAGE_SIZE, language: 'zh-cn' },
+      );
+      if (resp.data.code !== '0') return [];
+      return resp.data.info?.data || [];
+    } catch {
+      return [];
+    }
+  }
+
+  // ─── DocSource interface ───────────────────────────────────────────────
+
+  async fetchCatalog(): Promise<DocEntry[]> {
+    const entries: DocEntry[] = [];
+
+    for (const categoryType of [1, 2]) {
+      const typeName = categoryType === 1 ? 'API文档' : 'Webhook消息文档';
+      console.log(`[shein] 获取${typeName}分类列表...`);
+      const categories = await this.fetchCategoryList(categoryType);
+      console.log(`[shein] ${typeName}: ${categories.length} 个分类`);
+
+      for (const cat of categories) {
+        this.categoryMap.set(cat.id, cat.categoryName);
+
+        for (const doc of cat.apiDocVoList) {
+          const docTypeName = categoryType === 1 ? 'api_reference' : 'event';
+          const urlPath = categoryType === 1 ? 'apidoc' : 'msgdoc';
+
+          entries.push({
+            path: `${cat.categoryName}/${doc.userDocName}`,
+            title: doc.userDocName,
+            apiPath: doc.openPath,
+            docType: docTypeName,
+            sourceUrl: `${BASE_URL}/documents/${urlPath}/detail/${doc.id}`,
+            platformId: String(doc.id),
+          });
+        }
+
+        console.log(
+          `[shein] ${cat.categoryName}: ${cat.apiDocVoList.length} 篇`,
+        );
+      }
+    }
+
+    console.log(`[shein] 目录加载完成: ${entries.length} 篇文档`);
+    return entries;
+  }
+
+  async fetchContent(entry: DocEntry): Promise<DocContent> {
+    const docId = Number(entry.platformId);
+    if (!docId) {
+      throw new Error(`Missing platformId for entry: ${entry.title}`);
+    }
+
+    const detail = await this.fetchDetail(docId);
+    const docVo = detail.apiPublishDocVo;
+    const docDetail = detail.apiPublishDocDetailVo;
+
+    // ── Build Markdown ──────────────────────────────────────────────
+    const sections: string[] = [];
+
+    // Title
+    sections.push(`# ${docDetail.userDocName}\n`);
+
+    // Method + Path
+    sections.push(`**${docVo.method}** \`${docDetail.openPath}\`\n`);
+
+    // Category
+    const catName = this.categoryMap.get(docVo.categoryId) || '';
+    if (catName) {
+      sections.push(`分类：${catName}\n`);
+    }
+
+    // Supported modes
+    if (detail.modeNameList && detail.modeNameList.length > 0) {
+      sections.push(`适用模式：${detail.modeNameList.join('、')}\n`);
+    }
+
+    // Rate limit
+    if (docVo.qpsContent) {
+      sections.push(`限流：${docVo.qpsContent}次/秒\n`);
+    }
+
+    // Description
+    if (docDetail.description) {
+      const descMd = htmlToMarkdown(docDetail.description);
+      if (descMd) {
+        sections.push(`## 接口描述\n\n${descMd}\n`);
+      }
+    }
+
+    // Request header params
+    if (docDetail.requestHeader) {
+      const table = paramTreeToTable(docDetail.requestHeader);
+      if (table) {
+        sections.push(`## 请求参数（请求头）\n\n${table}\n`);
+      }
+    }
+
+    // Query string params
+    if (docDetail.queryStrings) {
+      const table = paramTreeToTable(docDetail.queryStrings);
+      if (table) {
+        sections.push(`## 请求参数（Query）\n\n${table}\n`);
+      }
+    }
+
+    // Request body params
+    if (docDetail.requestBody) {
+      const table = paramTreeToTable(docDetail.requestBody);
+      if (table) {
+        sections.push(`## 请求参数（请求体）\n\n${table}\n`);
+      }
+    }
+
+    // Response body params
+    if (docDetail.responseBody) {
+      const table = paramTreeToTable(docDetail.responseBody);
+      if (table) {
+        sections.push(`## 返回参数（响应体）\n\n${table}\n`);
+      }
+    }
+
+    // Request/Response examples
+    const examples = docDetail.apiPublishDocExampleDetailVo || [];
+    if (examples.length > 0) {
+      sections.push('## 请求返回示例\n');
+      for (const ex of examples) {
+        if (examples.length > 1) {
+          sections.push(`### ${ex.sceneName}\n`);
+        }
+        if (ex.requestExample) {
+          sections.push(`**请求示例**\n\n${htmlToMarkdown(ex.requestExample)}\n`);
+        }
+        if (ex.responseExample) {
+          sections.push(`**返回示例**\n\n${htmlToMarkdown(ex.responseExample)}\n`);
+        }
+      }
+    } else {
+      // Fallback to top-level examples
+      if (docDetail.requestExample) {
+        sections.push(`## 请求示例\n\n${htmlToMarkdown(docDetail.requestExample)}\n`);
+      }
+      if (docDetail.responseExample) {
+        sections.push(`## 返回示例\n\n${htmlToMarkdown(docDetail.responseExample)}\n`);
+      }
+    }
+
+    // Error codes
+    const errors = await this.fetchErrorList(docDetail.openPath);
+    const errorCodes: Array<{ code: string; message?: string; description?: string }> = [];
+
+    if (errors.length > 0) {
+      sections.push('## 业务错误码\n');
+      sections.push('| 错误码 | 错误信息 | 解决方案 |');
+      sections.push('| --- | --- | --- |');
+      for (const err of errors) {
+        sections.push(
+          `| ${escapeCell(err.errorCode)} | ${escapeCell(err.errorMsgCn || err.errorMsg)} | ${escapeCell(err.solution)} |`,
+        );
+        errorCodes.push({
+          code: err.errorCode,
+          message: err.errorMsgCn || err.errorMsg,
+          description: err.solution,
+        });
+      }
+      sections.push('');
+    }
+
+    const markdown = sections.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+
+    // Tokenize for FTS
+    const metadata: Record<string, unknown> = {
+      tokenizedTitle: tokenize(entry.title),
+      tokenizedContent: tokenize(markdown),
+    };
+
+    if (docVo.updateTime) {
+      // Format: "2025-12-26 14:35:50" → "2025-12-26"
+      metadata.lastUpdated = docVo.updateTime.split(' ')[0];
+    }
+
+    return {
+      markdown,
+      apiPath: docDetail.openPath,
+      errorCodes: errorCodes.length > 0 ? errorCodes : undefined,
+      metadata,
+    };
+  }
+
+  async detectUpdates(_since: Date): Promise<DocEntry[]> {
+    return this.fetchCatalog();
+  }
+}

--- a/scrapers/src/sync.ts
+++ b/scrapers/src/sync.ts
@@ -14,6 +14,7 @@ import { YouzanSource } from './sources/youzan.js';
 import { WechatPaySource } from './sources/wechat-pay.js';
 import { AlipaySource } from './sources/alipay.js';
 import { JdSource } from './sources/jd.js';
+import { SheinSource } from './sources/shein.js';
 import { OpenAPISource } from './sources/openapi.js';
 
 // ── 默认值 ──────────────────────────────────────────────────────────────
@@ -38,6 +39,7 @@ const SOURCE_CONCURRENCY: Record<string, number> = {
   'wechat-pay': 3,
   alipay: 3,
   jd: 1,  // Playwright 串行导航
+  shein: 3,
 };
 
 // ── Source 注册表 ────────────────────────────────────────────────────────
@@ -60,6 +62,7 @@ const SOURCE_REGISTRY: Record<string, SourceFactory> = {
   'wechat-pay': { create: () => new WechatPaySource() },
   alipay: { create: () => new AlipaySource() },
   jd: { create: () => new JdSource() },
+  shein: { create: () => new SheinSource() },
 };
 
 export function registerOpenAPISource(

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: specfusion
 description: |
-  搜索企业微信、飞书、钉钉、淘宝开放平台、小红书、抖音电商开放平台、微信小程序、微信小店、拼多多开放平台、有赞开放平台、微信支付、支付宝开放平台、京东商家开放平台等开放平台的 API 文档。当用户询问以下内容时自动触发：
-  - 企业微信/飞书/钉钉/淘宝/小红书/抖音电商/微信小程序/微信小店/拼多多/有赞/微信支付/支付宝/京东等平台的 API 用法、参数、接口说明
+  搜索企业微信、飞书、钉钉、淘宝开放平台、小红书、抖音电商开放平台、微信小程序、微信小店、拼多多开放平台、有赞开放平台、微信支付、支付宝开放平台、京东商家开放平台、SHEIN开放平台等开放平台的 API 文档。当用户询问以下内容时自动触发：
+  - 企业微信/飞书/钉钉/淘宝/小红书/抖音电商/微信小程序/微信小店/拼多多/有赞/微信支付/支付宝/京东/SHEIN等平台的 API 用法、参数、接口说明
   - 如何调用某个开放平台接口（发消息、获取用户、创建审批等）
   - 开放平台的 webhook、回调、事件订阅配置
   - OAuth、授权、access_token 获取流程
   - 任何涉及第三方平台 OpenAPI 规范的开发问题
-  触发关键词：企业微信、飞书、钉钉、淘宝、小红书、抖音电商、抖店、微信小程序、小程序、微信小店、小店、拼多多、pdd、有赞、youzan、微信支付、wechat-pay、wechatpay、支付宝、alipay、京东、jd、京东开放平台、开放平台、API文档、接口文档、
+  触发关键词：企业微信、飞书、钉钉、淘宝、小红书、抖音电商、抖店、微信小程序、小程序、微信小店、小店、拼多多、pdd、有赞、youzan、微信支付、wechat-pay、wechatpay、支付宝、alipay、京东、jd、京东开放平台、SHEIN、shein、sheincorp、开放平台、API文档、接口文档、
   wecom、feishu、lark、dingtalk、taobao、xiaohongshu、xhs、douyin、jinritemai、wechat、miniprogram、wechat-shop、channels、pinduoduo、youzanyun、电商开放平台、openapi、webhook、access_token
 user-invocable: true
-argument-hint: "企业微信发送消息 / feishu 审批 / 淘宝商品发布 / 小红书订单 / 抖音电商订单 / 微信小程序登录 / 微信小店订单 / 拼多多订单 / 有赞交易 / 微信支付JSAPI下单 / 支付宝当面付 / 京东商品API / 搜索关键词"
+argument-hint: "企业微信发送消息 / feishu 审批 / 淘宝商品发布 / 小红书订单 / 抖音电商订单 / 微信小程序登录 / 微信小店订单 / 拼多多订单 / 有赞交易 / 微信支付JSAPI下单 / 支付宝当面付 / 京东商品API / SHEIN商品发布 / 搜索关键词"
 allowed-tools: Bash, Read
 ---
 
 # SpecFusion — 多源 API 文档搜索
 
-你可以通过云端 API 搜索企业微信、飞书、钉钉、淘宝开放平台、小红书、抖音电商开放平台、微信小程序、微信小店、拼多多开放平台、有赞开放平台、微信支付、支付宝开放平台、京东商家开放平台等平台的开发文档。
+你可以通过云端 API 搜索企业微信、飞书、钉钉、淘宝开放平台、小红书、抖音电商开放平台、微信小程序、微信小店、拼多多开放平台、有赞开放平台、微信支付、支付宝开放平台、京东商家开放平台、SHEIN开放平台等平台的开发文档。
 
 ## API 端点
 
@@ -39,7 +39,7 @@ curl -s -G "http://specfusion.inagora.org/api/search" \
   - API 路径搜索：`/cgi-bin/message/send`、`/open-apis/contact/v3/users`
   - 错误码搜索：`60011`、`40001`、`errcode 40001`
   - 功能概念搜索：`客户联系`、`会话存档`、`消息卡片`
-- `source`（可选）：文档来源过滤，可选值为 wecom / feishu / dingtalk / taobao / xiaohongshu / douyin / wechat-miniprogram / wechat-shop / pinduoduo / youzan / wechat-pay / alipay / jd，不填搜索全部
+- `source`（可选）：文档来源过滤，可选值为 wecom / feishu / dingtalk / taobao / xiaohongshu / douyin / wechat-miniprogram / wechat-shop / pinduoduo / youzan / wechat-pay / alipay / jd / shein，不填搜索全部
 - `mode`（可选，仅企业微信）：开发模式过滤，可选值为 internal（自建应用）/ third_party（第三方应用）/ service_provider（服务商代开发）
 - `limit`（可选）：返回数量，默认 5，最大 20
 
@@ -175,6 +175,7 @@ curl -s -G "http://specfusion.inagora.org/api/recent" \
    - 微信支付：https://pay.weixin.qq.com/doc/v3/merchant/4012062524
    - 支付宝开放平台：https://opendocs.alipay.com/open/
    - 京东商家开放平台：https://open.jd.com/v2/#/doc/api
+   - SHEIN开放平台：https://open.sheincorp.com/documents/apidoc/detail/3001520
 
 ## 定位说明
 
@@ -199,3 +200,4 @@ curl -s -G "http://specfusion.inagora.org/api/recent" \
 | 微信支付 | wechat-pay | ~540 | JSAPI/APP/H5/Native/小程序支付、退款、分账、合单支付、代金券、商家转账等 API |
 | 支付宝开放平台 | alipay | ~600 | 当面付、APP支付、手机网站支付、电脑网站支付、资金、会员、营销、安全等 API |
 | 京东商家开放平台 | jd | ~6,100 | 商品、订单、物流、售后、促销、店铺、数据、发票、供应商等 API |
+| SHEIN开放平台 | shein | ~190 | 密钥授权、商品、订单、退货退款、采购单、库存、财务、物流、Webhook 等 API |


### PR DESCRIPTION
## Summary

- 新增 SHEIN 开放平台 scraper，通过公开 JSON API 抓取 186 篇文档（169 API + 17 Webhook）
- 覆盖密钥授权、商品、订单、退货退款、采购单、库存和销量、财务、面料、物流、店铺、MES、认证仓、MDP印染、Webhook 等 15 个分类
- 纯 HTTP API 方案（axios + cheerio），无需 Playwright，并发度 3，全量同步约 2.5 分钟

## Changes

- `scrapers/src/sources/shein.ts` — 新增 SHEIN scraper（目录 API + 详情 API + 错误码 API）
- `scrapers/src/sync.ts` — 注册 SheinSource，并发度 3
- `scrapers/config/sources.yaml` — 添加 shein 配置
- `api/src/routes/recent.ts` / `categories.ts` / `services/search-engine.ts` — SOURCE_NAME_MAP 新增 shein
- `Makefile` — 新增 sync-shein 目标
- `skill/SKILL.md` — 更新 description、触发关键词、source 参数、文档源表格、降级链接
- `README.md` — 更新标题、文档数量（26,580+）、平台表格、使用示例、同步命令

## Test plan

- [x] TypeScript 编译通过（scrapers + api）
- [x] 小量测试（--limit 5）成功入库，搜索验证通过
- [x] 全量同步 186 篇文档，0 错误
- [ ] `make upload-db` 上传数据库到 K8s
- [ ] `make deploy` 部署代码变更

🤖 Generated with [Claude Code](https://claude.com/claude-code)